### PR TITLE
Add warehouse-drone image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,7 @@ pipeline:
     commands:
       - dockerfile_lint -f futurelearn-drone/Dockerfile
       - dockerfile_lint -f futurelearn-ruby/Dockerfile
+      - dockerfile_lint -f warehouse-drone/Dockerfile
 
   futurelearn-drone publish:
     group: publish
@@ -26,6 +27,18 @@ pipeline:
       - latest
       - "${DRONE_BUILD_NUMBER}"
       - 2.5.1
+    secrets: [ docker_username, docker_password ]
+    when:
+      branch: master
+
+  warehouse-drone publish:
+    group: publish
+    image: plugins/docker
+    repo: futurelearn/warehouse-drone
+    dockerfile: warehouse-drone/Dockerfile
+    tags:
+      - latest
+      - "${DRONE_BUILD_NUMBER}"
     secrets: [ docker_username, docker_password ]
     when:
       branch: master

--- a/warehouse-drone/Dockerfile
+++ b/warehouse-drone/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.5.1-slim
+
+LABEL name="warehouse-ruby"
+LABEL version="2.5.1"
+
+ENV LANG     C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL   C.UTF-8
+
+RUN apt-get update -qq && apt-get install -y \
+  build-essential \
+  default-libmysqlclient-dev \
+  git \
+  libpq-dev \
+  mysql-client \
+  postgresql-client \
+  jq \
+  parallel \
+  && apt-get clean


### PR DESCRIPTION
As part of work to get the warehouse test suite running on drone I noticed
a bunch of dependencies needed by the warehouse, unsurprisingly, weren't 
installed as part of the base ruby image. Installing them as part of the drone
build step seems noisy, and causes excessive work to be done (those 
dependencies need to all be installed for each build twice). 

This commit adds a docker image for use by the warehouse in CI.

---

This is mostly based on the futurelearn-drone image with an adjusted set
of dependencies, and explicitly declared locale settings.

The locale needs to be set to something UTF-8 compatible as the test
suite exercises passing non-ASCII data to the shell. The ruby docker
hub page documents this setting under the heading "Encoding" 
<https://hub.docker.com/_/ruby/>

## Questions

* Is there anything I need to do in our docker account for the image 
  publishing to work?
* General comments appreciated, I'm unfamiliar with this repo so not
  100% sure this is the appropriate place to add this