### PR TITLE
Add gawk to warehouse-drone

### DIFF
--- a/warehouse-drone/Dockerfile
+++ b/warehouse-drone/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq && apt-get install -y \
   libpq-dev \
   mysql-client \
   postgresql-client \
+  gawk \
   jq \
   parallel \
   && apt-get clean


### PR DESCRIPTION
In [commit] our awk query for extracting log events by tag got a bit more
complex. On codeship, and in production we use GNU awk (gawk) which supports
features used in that query, however, the version of awk packaged with
ruby-slim is *not* compatible. Installing gawk fixes the issue.

[commit]: https://github.com/Futurelearn/data-warehouse/commit/b1fd9e1225852b88dee0a5ceea6c867b99b7c252#diff-884153ce4586ace63e19d0cab24a3844R54<Paste>