### PR TITLE
Add clamdscan wrapper

### DIFF
--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -9,6 +9,9 @@ RUN mkdir -p /var/lib/clamav && \
   chown -R clamav:clamav /var/lib/clamav && \
   freshclam --on-error-execute freshclam --no-dns
 
+RUN mv /usr/bin/clamdscan /usr/bin/clamdscan-original
+COPY clamdscan-wrapper.sh /usr/bin/clamdscan
+
 EXPOSE 3310
 
 CMD ["clamd"]

--- a/clamav/clamdscan-wrapper.sh
+++ b/clamav/clamdscan-wrapper.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+FILE=$1
+
+[[ -z "${FILE}" ]] && echo "Please provide a file" && exit 2
+
+COUNT=0
+while [[ "${COUNT}" -lt 10 ]]; do
+  test -f "${FILE}" && break
+  sleep 1
+  COUNT=$((COUNT+1))
+done
+
+if [[ "${COUNT}" -eq 10 ]]; then echo "Cannot access file ${FILE}" && exit 2; fi
+
+clamdscan-original --quiet --stdout "${FILE}"


### PR DESCRIPTION
We use this image as a sidecar next to an application container, and mount the same volume into both containers. Occasionally we see errors about "cannot access file" even when that file definitely exists on the volume mount, and is normally shortly rectified immediately afterwards.

Our working theory is that there can sometimes be a small delay in filesystem consistency between the two containers.

This adds a small wrapper that checks for the file existence for a maximum of 10 seconds. This was the simplest way to resolve this rare error.

## Note

Since the wrapper excepts only a filename as an argument, if we pass any additional commands to `clamdscan`, such as `--quiet`, these should be removed.