### PR TITLE
Add NGINX reverse proxy

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx
 
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat curl
 
 COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh

--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx
+
+RUN apt-get update && apt-get install -y netcat
+
+COPY entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+COPY default.conf /etc/nginx/default.conf.template
+
+ENTRYPOINT ["/opt/entrypoint.sh"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx-proxy/README.md
+++ b/nginx-proxy/README.md
@@ -1,0 +1,3 @@
+# nginx-proxy
+
+A small reverse proxy to forward error pages to an external location.

--- a/nginx-proxy/default.conf
+++ b/nginx-proxy/default.conf
@@ -1,0 +1,103 @@
+log_format log_json escape=json '{'
+  '"body_bytes_sent": $body_bytes_sent,'
+  '"content_length": "$content_length",'
+  '"content_type": "$content_type",'
+  '"gzip_ratio": "$gzip_ratio",'
+  '"host": "$host",'
+  '"http_cf_ray": "$http_cf_ray",'
+  '"http_dnt": "$http_dnt",'
+  '"http_referer": "$http_referer",'
+  '"http_user_agent": "$http_user_agent",'
+  '"http_x_forwarded_for": "$http_x_forwarded_for",'
+  '"remote_addr": "$remote_addr",'
+  '"remote_user": "$remote_user",'
+  '"request_completion": "$request_completion",'
+  '"request_method": "$request_method",'
+  '"request_time": "$request_time",'
+  '"request_uri": "$request_uri",'
+  '"status": $status,'
+  '"time_local": "$time_local",'
+  '"type": "nginx",'
+  '"upstream_cache_status": "$upstream_cache_status"'
+'}';
+
+upstream backend {
+  server ${BACKEND_HOST};
+}
+
+server {
+  listen ${PORT};
+
+  proxy_buffers 16 16k;
+  proxy_buffer_size 16k;
+
+  location / {
+    proxy_pass http://backend;
+  }
+
+  access_log /dev/stdout log_json;
+
+  proxy_intercept_errors on;
+  proxy_ssl_server_name on;
+
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Real-IP  $remote_addr;
+  proxy_set_header Host $http_host;
+  proxy_set_header If-Modified-Since $http_if_modified_since;
+
+  error_page 400 /400.html;
+  location = /400.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/400.html;
+  }
+
+  error_page 404 /404.html;
+  location = /404.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/404.html;
+  }
+
+  error_page 413 /413.html;
+  location = /413.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/413.html;
+  }
+
+  error_page 422 /422.html;
+  location = /422.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/422.html;
+  }
+
+  error_page 500 /500.html;
+  location = /500.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/500.html;
+  }
+
+  error_page 502 /502.html;
+  location = /502.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/502.html;
+  }
+
+  error_page 503 /503.html;
+  location = /503.html {
+    proxy_set_header Host ${STATIC_PAGES_HOST};
+    proxy_set_header Authorization '';
+
+    proxy_pass https://${STATIC_PAGES_HOST}/errors/503.html;
+  }
+}

--- a/nginx-proxy/entrypoint.sh
+++ b/nginx-proxy/entrypoint.sh
@@ -12,4 +12,19 @@ fi
 # shellcheck disable=SC2016
 envsubst '${BACKEND_HOST} ${STATIC_PAGES_HOST} ${PORT}' < /etc/nginx/default.conf.template > /etc/nginx/conf.d/default.conf
 
+REALIP_CONF_FILE="/etc/nginx/conf.d/http_realip.conf"
+
+echo "set_real_ip_from 10.0.0.0/8;" > $REALIP_CONF_FILE
+
+for i in $(curl -sSL https://www.cloudflare.com/ips-v4); do
+  echo "set_real_ip_from $i;" >> $REALIP_CONF_FILE
+done
+
+for i in $(curl -sSL https://www.cloudflare.com/ips-v6); do
+  echo "set_real_ip_from $i;" >> $REALIP_CONF_FILE
+done
+
+echo "real_ip_header X-Forwarded-For;" >> $REALIP_CONF_FILE
+echo "real_ip_recursive on;" >> $REALIP_CONF_FILE
+
 exec "$@"

--- a/nginx-proxy/entrypoint.sh
+++ b/nginx-proxy/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if [[ -z "${STATIC_PAGES_HOST}" ]]; then
+  echo "ERROR: Must set STATIC_PAGES_HOST environment variable"
+  exit 1
+fi
+
+[[ -z "${PORT}" ]]         && export PORT="80"
+[[ -z "${BACKEND_HOST}" ]] && export BACKEND_HOST="127.0.0.1"
+
+# shellcheck disable=SC2016
+envsubst '${BACKEND_HOST} ${STATIC_PAGES_HOST} ${PORT}' < /etc/nginx/default.conf.template > /etc/nginx/conf.d/default.conf
+
+exec "$@"


### PR DESCRIPTION
I tried in vain to use Traefik as a small reverse proxy since it forwarded error pages out of the box, and is built for cloud environments.

Unfortunately I ran into issues with the `Authorization` header being set when requesting the error page, and S3 failing since that header was set.

This replaces the functionality with Good Ole NGINX, and strips the `Authorization` header when we're passing on a request to an error page.

I've defined every single error page in a separate block with a separate `upstream` block for the static pages, since I ran into issues trying to be clever, where I had to set `resolver` configuration.

Basically, I got bored and decided not to be clever.