### PR TITLE
Add ECS response header

### DIFF
--- a/nginx-proxy/default.conf
+++ b/nginx-proxy/default.conf
@@ -10,6 +10,8 @@ server {
 
   location / {
     proxy_pass http://backend;
+
+    add_header ECS true always;
   }
 
   access_log /dev/stdout log_json;


### PR DESCRIPTION
Add a response header to the main `proxy_pass` pass location using the `add_header`[1] parameter.

As documented it will add the header no matter what the status code is.  This will help us determine the source of the response.

[1] https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
