### PR TITLE
Conditionally intercept errors

### DIFF
--- a/nginx-proxy/default.conf
+++ b/nginx-proxy/default.conf
@@ -2,6 +2,12 @@ upstream backend {
   server ${BACKEND_HOST};
 }
 
+map $content_type $intercept_errors {
+  default "intercept_errors_off";
+
+  "~*text/html" "intercept_errors_on";
+}
+
 server {
   listen ${PORT};
 
@@ -9,14 +15,25 @@ server {
   proxy_buffer_size 16k;
 
   location / {
-    proxy_pass http://backend;
+    rewrite / /$intercept_errors last;
+  }
 
+  location /intercept_errors_on {
     add_header ECS true always;
+    proxy_intercept_errors on;
+
+    proxy_pass http://backend$request_uri;
+  }
+
+  location /intercept_errors_off {
+    add_header ECS true always;
+    proxy_intercept_errors off;
+
+    proxy_pass http://backend$request_uri;
   }
 
   access_log /dev/stdout log_json;
 
-  proxy_intercept_errors on;
   proxy_ssl_server_name on;
 
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx-proxy/default.conf
+++ b/nginx-proxy/default.conf
@@ -2,10 +2,10 @@ upstream backend {
   server ${BACKEND_HOST};
 }
 
-map $content_type $intercept_errors {
-  default "intercept_errors_off";
+map $sent_http_content_type $intercept_errors {
+  default "no";
 
-  "~*text/html" "intercept_errors_on";
+  "~*text/html" "yes";
 }
 
 server {
@@ -13,24 +13,6 @@ server {
 
   proxy_buffers 16 16k;
   proxy_buffer_size 16k;
-
-  location / {
-    rewrite / /$intercept_errors last;
-  }
-
-  location /intercept_errors_on {
-    add_header ECS true always;
-    proxy_intercept_errors on;
-
-    proxy_pass http://backend$request_uri;
-  }
-
-  location /intercept_errors_off {
-    add_header ECS true always;
-    proxy_intercept_errors off;
-
-    proxy_pass http://backend$request_uri;
-  }
 
   access_log /dev/stdout log_json;
 
@@ -41,7 +23,24 @@ server {
   proxy_set_header Host $http_host;
   proxy_set_header If-Modified-Since $http_if_modified_since;
 
-  error_page 400 /400.html;
+  proxy_intercept_errors on;
+
+  location / {
+    add_header ECS true always;
+
+    proxy_pass http://backend;
+
+    if ($intercept_errors = "yes" ) {
+      error_page 400 /400.html;
+      error_page 404 /404.html;
+      error_page 413 /413.html;
+      error_page 422 /422.html;
+      error_page 500 /500.html;
+      error_page 502 /502.html;
+      error_page 503 /503.html;
+    }
+  }
+
   location = /400.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -49,7 +48,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/400.html;
   }
 
-  error_page 404 /404.html;
   location = /404.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -57,7 +55,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/404.html;
   }
 
-  error_page 413 /413.html;
   location = /413.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -65,7 +62,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/413.html;
   }
 
-  error_page 422 /422.html;
   location = /422.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -73,7 +69,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/422.html;
   }
 
-  error_page 500 /500.html;
   location = /500.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -81,7 +76,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/500.html;
   }
 
-  error_page 502 /502.html;
   location = /502.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';
@@ -89,7 +83,6 @@ server {
     proxy_pass https://${STATIC_PAGES_HOST}/errors/502.html;
   }
 
-  error_page 503 /503.html;
   location = /503.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};
     proxy_set_header Authorization '';

--- a/nginx-proxy/maintenance.conf
+++ b/nginx-proxy/maintenance.conf
@@ -13,10 +13,12 @@ server {
   }
 
   location / {
+    if ($content_type ~* "text/html") {
+      error_page 503 /503.html;
+    }
+
     return 503;
   }
-
-  error_page 503 /503.html;
 
   location /503.html {
     proxy_set_header Host ${STATIC_PAGES_HOST};


### PR DESCRIPTION
We need to conditionally intercept errors based upon the `Content-Type` header. When our content is `text/html`, we would expect to return an HTML error page.

Otherwise, we should not intercept errors, and instead pass back the response by application.

I was hoping to use `proxy_intercept_errors` within an if statement, but alas this not allowed in NGINX[1].

What we can do is use the `map` module[2] which is not dissimilar to using an `if` statement.

We do a regex check based upon the built-in `$content_type` variable, and if it matches `text/html`, then we set the `$intercept_errors` variable to `intercept_errors_on`, otherwise we set it to the default of `intercept_errors_off`.

We then use `rewrite`[3] to rewrite all requests to the location matching the variable.

Using two location blocks, we can set `proxy_intercept_errors` to the appropriate value.

We must use `$request_uri` as part of the `proxy_pass` argument otherwise the `intercept_errors_on` or `intercept_errors_off` path will also be included.

The maintenance page is simpler since it always redirects to a static page, but if it's not Content-Type `text/html`. then we should return with a static error.

Since the upstream application is static, we cannot pass through any response back from the application.

## Questions

Is there a static response string we'd rather serve for the maintenance page rather than the default NGINX error page?

[1] https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
[2] https://nginx.org/en/docs/http/ngx_http_map_module.html
[3] https://nginx.org/en/docs/http/ngx_http_rewrite_module.html